### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jondavid-black/git-rest/security/code-scanning/1](https://github.com/jondavid-black/git-rest/security/code-scanning/1)

To fix this issue, explicitly set a `permissions:` block in the workflow. This can be done either at the workflow root (before jobs:) to cover all jobs, or within each job itself. Since there's only one job, either placement is acceptable, but root-level makes the intent clearer for future job additions. The vast majority of the workflow steps do not require any GITHUB_TOKEN access at all. The only step that might need any access is `actions/checkout@v4`; for most use-cases, it can work with `contents: read`, the minimal permission recommended by CodeQL. Therefore, add:

```yaml
permissions:
  contents: read
```
on its own line just after the workflow name (`name: CI`). No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
